### PR TITLE
Reset prompt string after command is executed

### DIFF
--- a/app.go
+++ b/app.go
@@ -361,8 +361,7 @@ Loop:
 			continue Loop
 		}
 
-		// Reset to default prompt and save history.
-		a.rl.SetPrompt(a.config.prompt())
+		// Save history.
 		a.rl.SaveHistory(line)
 
 		// Split the line to args.
@@ -374,6 +373,11 @@ Loop:
 
 		// Execute the command.
 		err = a.RunCommand(args)
+
+		// Reset to default prompt.
+		a.rl.SetPrompt(a.config.prompt())
+
+		// Handle execute errors.
 		if err != nil {
 			a.PrintError(err)
 			continue Loop


### PR DESCRIPTION
This PR allows to reset the prompt string whlie executing a command and make sure that the new prompt will be desplayed immediately. In contrast, the current implemetation requires to run another command before displaying the new prompt.

Test by calling the following func in a Run func of a command:

``` go
func setPrompt(p string) {
	App.Config().Prompt = fmt.Sprintf("%s > ", p)
}
```

This PR solves Issue #1 