### PR TITLE
added Printf

### DIFF
--- a/app.go
+++ b/app.go
@@ -129,6 +129,16 @@ func (a *App) PrintError(err error) {
 	}
 }
 
+// Printf formats according to a format specifier and writes to terminal output.
+// Method writes to standard output if terminal output is not yet active.
+func (a *App) Printf(format string, args ...interface{}) (int, error) {
+	if a.rl != nil {
+		return a.rl.Write([]byte(fmt.Sprintf(format, args...)))
+	}
+
+	return fmt.Printf(format, args...)
+}
+
 // OnInit sets the function which will be executed before the first command
 // is executed. App flags can be handled here.
 func (a *App) OnInit(f func(a *App, flags FlagMap) error) {


### PR DESCRIPTION
This method writes to terminal output without interfering with line editor.
The following code prints line each two seconds and does not write over current line being edited.

```	
app.OnInit(func(a *grumble.App, _ grumble.FlagMap) error {
	go func() {
		for {
			time.Sleep(2 * time.Second)
			a.Printf("time: %s\n", time.Now().Format(time.RFC3339))
		}
	}()
	return nil
})
```