### PR TITLE
Fix error display on Windows

### DIFF
--- a/app.go
+++ b/app.go
@@ -125,7 +125,8 @@ func (a *App) PrintError(err error) {
 	if a.config.NoColor {
 		fmt.Printf("error: %v\n", err)
 	} else {
-		fmt.Printf("%s %v\n", a.config.ErrorColor.Sprintf("error:"), err)
+		a.config.ErrorColor.Print("error: ")
+		fmt.Printf("%v\n", err)
 	}
 }
 

--- a/app.go
+++ b/app.go
@@ -295,7 +295,7 @@ func (a *App) Run() (err error) {
 		Name: "clear",
 		Help: "clear the screen",
 		Run: func(c *Context) error {
-			_, _ = readline.ClearScreen(a.rl)
+			readline.ClearScreen(a.rl)
 			return nil
 		},
 	})


### PR DESCRIPTION
Fixes error messages display on Windows due to the color formatting.

_Before_:
![grumble_winerror_before](https://user-images.githubusercontent.com/41601236/71045750-739f6d00-2136-11ea-958d-ef3fcc978f40.png)

_After_:
![grumble_winerror_after](https://user-images.githubusercontent.com/41601236/71045756-78fcb780-2136-11ea-91bf-67132b87f9f3.png)

Tested inside a Win10 x64 VM.