### PR TITLE
Add arguments validation (empty, min, max, exact and range)

### DIFF
--- a/app.go
+++ b/app.go
@@ -295,7 +295,7 @@ func (a *App) Run() (err error) {
 	a.addCommand(&Command{
 		Name:         "help",
 		Help:         "use 'help [command]' for command help",
-		ExpectedArgs: MaximumNArgs(1),
+		ExpectedArgs: MaximumNArgs(6),
 		Run: func(c *Context) error {
 			if len(c.Args) == 0 {
 				a.printHelp(a, a.isShell)

--- a/app.go
+++ b/app.go
@@ -293,7 +293,6 @@ func (a *App) Run() (err error) {
 	a.addCommand(&Command{
 		Name:         "help",
 		Help:         "use 'help [command]' for command help",
-		AllowArgs:    true,
 		ExpectedArgs: MaximumNArgs(1),
 		Run: func(c *Context) error {
 			if len(c.Args) == 0 {

--- a/app.go
+++ b/app.go
@@ -235,9 +235,14 @@ func (a *App) RunCommand(args []string) error {
 	// The last command is the final command.
 	cmd := cmds[len(cmds)-1]
 
-	// Check if arguments are allowed.
-	if !cmd.AllowArgs && len(args) > 0 {
-		return fmt.Errorf("command '%s' requires no arguments, try 'help'", cmd.Name)
+	// ExpectedArgs can't be nil
+	if cmd.ExpectedArgs == nil {
+		cmd.ExpectedArgs = NoArgs
+	}
+
+	// Validate the arguments.
+	if err = cmd.ExpectedArgs(args); err != nil {
+		return err
 	}
 
 	// Print the command help if the command run function is nil or if the help flag is set.
@@ -286,9 +291,10 @@ func (a *App) Run() (err error) {
 
 	// Add general builtin commands.
 	a.addCommand(&Command{
-		Name:      "help",
-		Help:      "use 'help [command]' for command help",
-		AllowArgs: true,
+		Name:         "help",
+		Help:         "use 'help [command]' for command help",
+		AllowArgs:    true,
+		ExpectedArgs: MaximumNArgs(1),
 		Run: func(c *Context) error {
 			if len(c.Args) == 0 {
 				a.printHelp(a, a.isShell)

--- a/app.go
+++ b/app.go
@@ -235,14 +235,16 @@ func (a *App) RunCommand(args []string) error {
 	// The last command is the final command.
 	cmd := cmds[len(cmds)-1]
 
-	// ExpectedArgs can't be nil
+	// ExpectedArgs can't be nil.
 	if cmd.ExpectedArgs == nil {
 		cmd.ExpectedArgs = NoArgs
 	}
 
 	// Validate the arguments.
-	if err = cmd.ExpectedArgs(args); err != nil {
-		return err
+	if !cmd.AllowArgs {
+		if err = cmd.ExpectedArgs(args); err != nil {
+			return err
+		}
 	}
 
 	// Print the command help if the command run function is nil or if the help flag is set.

--- a/arguments.go
+++ b/arguments.go
@@ -1,0 +1,56 @@
+package grumble
+
+import (
+	"fmt"
+)
+
+// ExpectedArgs defines the expected arguments for a command.
+type ExpectedArgs func(args []string) error
+
+// NoArgs returns an error if any args are included.
+func NoArgs(args []string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("unknown command: %q", args[0])
+	}
+	return nil
+}
+
+// MinimumNArgs returns an error if there is not at least N args.
+func MinimumNArgs(n int) ExpectedArgs {
+	return func(args []string) error {
+		if len(args) < n {
+			return fmt.Errorf("requires at least %d arg(s), only received %d", n, len(args))
+		}
+		return nil
+	}
+}
+
+// MaximumNArgs returns an error if there are more than N args.
+func MaximumNArgs(n int) ExpectedArgs {
+	return func(args []string) error {
+		if len(args) > n {
+			return fmt.Errorf("accepts at most %d arg(s), received %d", n, len(args))
+		}
+		return nil
+	}
+}
+
+// ExactArgs returns an error if there are not exactly n args.
+func ExactArgs(n int) ExpectedArgs {
+	return func(args []string) error {
+		if len(args) != n {
+			return fmt.Errorf("accepts %d arg(s), received %d", n, len(args))
+		}
+		return nil
+	}
+}
+
+// RangeArgs returns an error if the number of args is not within the expected range.
+func RangeArgs(min int, max int) ExpectedArgs {
+	return func(args []string) error {
+		if len(args) < min || len(args) > max {
+			return fmt.Errorf("accepts between %d and %d arg(s), received %d", min, max, len(args))
+		}
+		return nil
+	}
+}

--- a/arguments.go
+++ b/arguments.go
@@ -35,7 +35,7 @@ func MaximumNArgs(n int) ExpectedArgs {
 	}
 }
 
-// ExactArgs returns an error if there are not exactly n args.
+// ExactArgs returns an error if there are not exactly N args.
 func ExactArgs(n int) ExpectedArgs {
 	return func(args []string) error {
 		if len(args) != n {

--- a/command.go
+++ b/command.go
@@ -56,7 +56,11 @@ type Command struct {
 	Flags func(f *Flags)
 
 	// Define if the command is allowed to get arguments.
+	// Deprecated: AllowArgs isn't evaluated in favor of ExpectedArgs.
 	AllowArgs bool
+
+	// Expected arguments.
+	ExpectedArgs ExpectedArgs
 
 	// Function to execute for the command.
 	Run func(c *Context) error

--- a/sample/full/cmd/daemon.go
+++ b/sample/full/cmd/daemon.go
@@ -34,11 +34,11 @@ import (
 
 func init() {
 	App.AddCommand(&grumble.Command{
-		Name:      "daemon",
-		Help:      "run the daemon",
-		Aliases:   []string{"run"},
-		Usage:     "daemon [OPTIONS]",
-		AllowArgs: true,
+		Name:         "daemon",
+		Help:         "run the daemon",
+		Aliases:      []string{"run"},
+		Usage:        "daemon [OPTIONS] [ARGS]",
+		ExpectedArgs: grumble.MaximumNArgs(3),
 		Flags: func(f *grumble.Flags) {
 			f.Duration("t", "timeout", time.Second, "timeout duration")
 		},
@@ -47,9 +47,11 @@ func init() {
 			fmt.Println("directory:", c.Flags.String("directory"))
 			fmt.Println("verbose:", c.Flags.Bool("verbose"))
 
-			// Handle args.
-			fmt.Println("args:")
-			fmt.Println(strings.Join(c.Args, "\n"))
+			// The command accepts up to 3 optional arguments.
+			if len(c.Args) > 0 {
+				fmt.Println("args:")
+				fmt.Println(strings.Join(c.Args, "\n"))
+			}
 
 			return nil
 		},

--- a/sample/full/cmd/prompt.go
+++ b/sample/full/cmd/prompt.go
@@ -36,10 +36,18 @@ func init() {
 	App.AddCommand(promptCommand)
 
 	promptCommand.AddCommand(&grumble.Command{
-		Name: "set",
-		Help: "set a custom prompt",
+		Name:         "set",
+		Help:         "set a custom prompt",
+		Usage:        "prompt set [ARG]",
+		ExpectedArgs: grumble.MaximumNArgs(1),
 		Run: func(c *grumble.Context) error {
-			c.App.SetPrompt("CUSTOM PROMPT >> ")
+			var customPrompt = "CUSTOM PROMPT >> "
+
+			if len(c.Args) == 1 {
+				customPrompt = c.Args[0]
+			}
+
+			c.App.SetPrompt(customPrompt)
 			return nil
 		},
 	})

--- a/sample/simple/cmd/app.go
+++ b/sample/simple/cmd/app.go
@@ -43,11 +43,11 @@ var App = grumble.New(&grumble.Config{
 
 func init() {
 	App.AddCommand(&grumble.Command{
-		Name:      "daemon",
-		Help:      "run the daemon",
-		Aliases:   []string{"run"},
-		Usage:     "daemon [OPTIONS]",
-		AllowArgs: true,
+		Name:         "daemon",
+		Help:         "run the daemon",
+		Aliases:      []string{"run"},
+		Usage:        "daemon [OPTIONS] [ARGS]",
+		ExpectedArgs: grumble.MaximumNArgs(3),
 		Flags: func(f *grumble.Flags) {
 			f.Duration("t", "timeout", time.Second, "timeout duration")
 		},
@@ -56,9 +56,11 @@ func init() {
 			c.App.Println("directory:", c.Flags.String("directory"))
 			c.App.Println("verbose:", c.Flags.Bool("verbose"))
 
-			// Handle args.
-			c.App.Println("args:")
-			c.App.Println(strings.Join(c.Args, "\n"))
+			// The command accepts up to 3 optional arguments.
+			if len(c.Args) > 0 {
+				c.App.Println("args:")
+				c.App.Println(strings.Join(c.Args, "\n"))
+			}
 
 			return nil
 		},


### PR DESCRIPTION
- The feature is very close (if not identical) to the one found in [Cobra](https://github.com/spf13/cobra).
- Only the number of arguments is checked, not the values (yet).
- `Command.AllowArgs` has been tagged as deprecated, but still exists in the code to preserve backward compatibility.
