### PR TITLE
discard line content after cursor pos in auto complete

### DIFF
--- a/completer.go
+++ b/completer.go
@@ -41,6 +41,10 @@ func newCompleter(commands *Commands) *completer {
 }
 
 func (c *completer) Do(line []rune, pos int) (newLine [][]rune, length int) {
+	// Discard anything after the cursor position.
+	// This is similar behaviour to shell/bash.
+	line = line[:pos]
+
 	var words []string
 	if w, err := shlex.Split(string(line), true); err == nil {
 		words = w
@@ -49,7 +53,7 @@ func (c *completer) Do(line []rune, pos int) (newLine [][]rune, length int) {
 	}
 
 	prefix := ""
-	if len(words) > 0 && line[pos-1] != ' ' {
+	if len(words) > 0 && pos >= 1 && line[pos-1] != ' ' {
 		prefix = words[len(words)-1]
 		words = words[:len(words)-1]
 	}


### PR DESCRIPTION
This proposes a fix for issue #21. In the auto completer, it discards the `line` content after the cursor position `pos`. This leads to the following behaviour:  
- user types a command and moves cursor back -> anything after the cursor is discarded
- fixes the situation, where the user moves the cursor back to the beginning, which crashed

The behaviour is similar to what bash / sh are doing. When typing `ssh` in my shell, then moving my cursor back by 1 (`ss|h`, `|` being my cursor position) it suggests again all commands with prefix `ss`. It basically discards the `h` after the cursor.

closes #21 