### PR TITLE
Add string slice flag

### DIFF
--- a/flagmap.go
+++ b/flagmap.go
@@ -64,6 +64,30 @@ func (f FlagMap) String(long string) string {
 	return s
 }
 
+// 210521: JC0o0l Add
+func (f FlagMap) StringSlice(long string) []string {
+	i := f[long]
+	if i == nil {
+		panic(fmt.Errorf("missing flag value: flag '%s' not registered", long))
+	}
+	// 210520: JC0o0l Modify
+	s := make([]string, 0)
+	//fmt.Printf("%T,%v\n", i.Value, i.Value)
+	//jlog.Debug(len(i.Value.([]interface{})))
+	if len(i.Value.([]interface{})) == 0 {
+		return s
+	}
+	for _, v := range i.Value.([]interface{}) {
+		s = append(s, v.(string))
+	}
+	//s, ok := i.Value.([]string)
+	//if !ok {
+	//	panic(fmt.Errorf("failed to assert flag '%s' to string", long))
+	//}
+	return s
+}
+// JC0o0l End
+
 // Bool returns the given flag value as boolean.
 // Panics if not present. Flags must be registered.
 func (f FlagMap) Bool(long string) bool {

--- a/flagmap.go
+++ b/flagmap.go
@@ -71,12 +71,10 @@ func (f FlagMap) StringSlice(long string) []string {
 	if i == nil {
 		panic(fmt.Errorf("missing flag value: flag '%s' not registered", long))
 	}
-	s := make([]string, 0)
-	if len(i.Value.([]interface{})) == 0 {
-		return s
-	}
-	for _, v := range i.Value.([]interface{}) {
-		s = append(s, v.(string))
+	sliceCount := len(i.Value.([]interface{}))
+	s := make([]string, sliceCount)
+	for k, v := range i.Value.([]interface{}) {
+		s[k] = v.(string)
 	}
 	return s
 }

--- a/flagmap.go
+++ b/flagmap.go
@@ -64,29 +64,22 @@ func (f FlagMap) String(long string) string {
 	return s
 }
 
-// 210521: JC0o0l Add
+// StringSlice returns the given flag value as string slice.
+// Panics if not present. Flags must be registered.
 func (f FlagMap) StringSlice(long string) []string {
 	i := f[long]
 	if i == nil {
 		panic(fmt.Errorf("missing flag value: flag '%s' not registered", long))
 	}
-	// 210520: JC0o0l Modify
 	s := make([]string, 0)
-	//fmt.Printf("%T,%v\n", i.Value, i.Value)
-	//jlog.Debug(len(i.Value.([]interface{})))
 	if len(i.Value.([]interface{})) == 0 {
 		return s
 	}
 	for _, v := range i.Value.([]interface{}) {
 		s = append(s, v.(string))
 	}
-	//s, ok := i.Value.([]string)
-	//if !ok {
-	//	panic(fmt.Errorf("failed to assert flag '%s' to string", long))
-	//}
 	return s
 }
-// JC0o0l End
 
 // Bool returns the given flag value as boolean.
 // Panics if not present. Flags must be registered.

--- a/flags.go
+++ b/flags.go
@@ -202,7 +202,6 @@ func (f *Flags) String(short, long, defaultValue, help string) {
 		})
 }
 
-//210521: JC0o0l Add
 // StringSlice registers a stringSlice flag.
 func (f *Flags) StringSlice(short, long string, defaultValue []string, help string) {
 	f.register(short, long, help, "stringSlice", true, defaultValue,
@@ -217,23 +216,11 @@ func (f *Flags) StringSlice(short, long string, defaultValue []string, help stri
 
 		},
 		func(flag, equalVal string, args []string, res FlagMap) ([]string, bool, error) {
-			//defer func(){
-			//	jlog.Debug(args)
-			//}()
-			//jlog.Debug(flag,equalVal,args,res)
 			if !f.match(flag, short, long) {
 				return args, false, nil
 			}
 			if len(equalVal) > 0 {
-				//res[long] = &FlagMapItem{
-				//	Value:     trimQuotes(equalVal),
-				//	IsDefault: false,
-				//}
 				if res[long] != nil {
-					//res[long] = &FlagMapItem{
-					//	Value:     append(res[long].Value.([]interface{}),args[0]),
-					//	IsDefault: false,
-					//}
 					res[long].Value = append(res[long].Value.([]interface{}), trimQuotes(equalVal))
 					res[long].IsDefault = false
 				} else {
@@ -250,10 +237,6 @@ func (f *Flags) StringSlice(short, long string, defaultValue []string, help stri
 				return args, false, fmt.Errorf("missing string value for flag: %s", flag)
 			}
 			if res[long] != nil {
-				//res[long] = &FlagMapItem{
-				//	Value:     append(res[long].Value.([]interface{}),args[0]),
-				//	IsDefault: false,
-				//}
 				res[long].Value = append(res[long].Value.([]interface{}), args[0])
 				res[long].IsDefault = false
 			} else {
@@ -265,12 +248,10 @@ func (f *Flags) StringSlice(short, long string, defaultValue []string, help stri
 				res[long].IsDefault = false
 			}
 
-			//jlog.Debug("grumble flags:",args)
 			args = args[1:]
 			return args, true, nil
 		})
 }
-//JC0o0l End
 
 // BoolL same as Bool, but without a shorthand.
 func (f *Flags) BoolL(long string, defaultValue bool, help string) {

--- a/flags.go
+++ b/flags.go
@@ -220,33 +220,27 @@ func (f *Flags) StringSlice(short, long string, defaultValue []string, help stri
 				return args, false, nil
 			}
 			if len(equalVal) > 0 {
-				if res[long] != nil {
-					res[long].Value = append(res[long].Value.([]interface{}), trimQuotes(equalVal))
-					res[long].IsDefault = false
-				} else {
+				if res[long] == nil {
 					res[long] = &FlagMapItem{
 						Value:     make([]interface{}, 0),
 						IsDefault: false,
 					}
-					res[long].Value = append(res[long].Value.([]interface{}), trimQuotes(equalVal))
-					res[long].IsDefault = false
 				}
+				res[long].Value = append(res[long].Value.([]interface{}), trimQuotes(equalVal))
+				res[long].IsDefault = false
 				return args, true, nil
 			}
 			if len(args) == 0 {
 				return args, false, fmt.Errorf("missing string value for flag: %s", flag)
 			}
-			if res[long] != nil {
-				res[long].Value = append(res[long].Value.([]interface{}), args[0])
-				res[long].IsDefault = false
-			} else {
+			if res[long] == nil {
 				res[long] = &FlagMapItem{
 					Value:     make([]interface{}, 0),
 					IsDefault: false,
 				}
-				res[long].Value = append(res[long].Value.([]interface{}), args[0])
-				res[long].IsDefault = false
 			}
+			res[long].Value = append(res[long].Value.([]interface{}), args[0])
+			res[long].IsDefault = false
 
 			args = args[1:]
 			return args, true, nil

--- a/flags.go
+++ b/flags.go
@@ -202,6 +202,76 @@ func (f *Flags) String(short, long, defaultValue, help string) {
 		})
 }
 
+//210521: JC0o0l Add
+// StringSlice registers a stringSlice flag.
+func (f *Flags) StringSlice(short, long string, defaultValue []string, help string) {
+	f.register(short, long, help, "stringSlice", true, defaultValue,
+		func(res FlagMap) {
+			res[long] = &FlagMapItem{
+				Value:     []interface{}{},
+				IsDefault: true,
+			}
+			for _, v := range defaultValue {
+				res[long].Value = append(res[long].Value.([]interface{}), v)
+			}
+
+		},
+		func(flag, equalVal string, args []string, res FlagMap) ([]string, bool, error) {
+			//defer func(){
+			//	jlog.Debug(args)
+			//}()
+			//jlog.Debug(flag,equalVal,args,res)
+			if !f.match(flag, short, long) {
+				return args, false, nil
+			}
+			if len(equalVal) > 0 {
+				//res[long] = &FlagMapItem{
+				//	Value:     trimQuotes(equalVal),
+				//	IsDefault: false,
+				//}
+				if res[long] != nil {
+					//res[long] = &FlagMapItem{
+					//	Value:     append(res[long].Value.([]interface{}),args[0]),
+					//	IsDefault: false,
+					//}
+					res[long].Value = append(res[long].Value.([]interface{}), trimQuotes(equalVal))
+					res[long].IsDefault = false
+				} else {
+					res[long] = &FlagMapItem{
+						Value:     make([]interface{}, 0),
+						IsDefault: false,
+					}
+					res[long].Value = append(res[long].Value.([]interface{}), trimQuotes(equalVal))
+					res[long].IsDefault = false
+				}
+				return args, true, nil
+			}
+			if len(args) == 0 {
+				return args, false, fmt.Errorf("missing string value for flag: %s", flag)
+			}
+			if res[long] != nil {
+				//res[long] = &FlagMapItem{
+				//	Value:     append(res[long].Value.([]interface{}),args[0]),
+				//	IsDefault: false,
+				//}
+				res[long].Value = append(res[long].Value.([]interface{}), args[0])
+				res[long].IsDefault = false
+			} else {
+				res[long] = &FlagMapItem{
+					Value:     make([]interface{}, 0),
+					IsDefault: false,
+				}
+				res[long].Value = append(res[long].Value.([]interface{}), args[0])
+				res[long].IsDefault = false
+			}
+
+			//jlog.Debug("grumble flags:",args)
+			args = args[1:]
+			return args, true, nil
+		})
+}
+//JC0o0l End
+
 // BoolL same as Bool, but without a shorthand.
 func (f *Flags) BoolL(long string, defaultValue bool, help string) {
 	f.Bool("", long, defaultValue, help)

--- a/sample/full/cmd/flags.go
+++ b/sample/full/cmd/flags.go
@@ -42,16 +42,16 @@ func init() {
 			f.Uint("u", "uint", 3, "test uint")
 			f.Uint64("j", "uint64", 4, "test uint64")
 			f.Float64("f", "float", 5.55, "test float64")
-			f.StringSlice("H","Headers",[]string{},"string slice")
+			f.StringSlice("s", "stringSlice", []string{}, "test stringSlice")
 		},
 		Run: func(c *grumble.Context) error {
-			fmt.Println("duration ", c.Flags.Duration("duration"))
-			fmt.Println("int      ", c.Flags.Int("int"))
-			fmt.Println("int64    ", c.Flags.Int64("int64"))
-			fmt.Println("uint     ", c.Flags.Uint("uint"))
-			fmt.Println("uint64   ", c.Flags.Uint64("uint64"))
-			fmt.Println("float    ", c.Flags.Float64("float"))
-			fmt.Println("StringSLice",c.Flags.StringSlice("Headers"))
+			fmt.Println("duration    ", c.Flags.Duration("duration"))
+			fmt.Println("int         ", c.Flags.Int("int"))
+			fmt.Println("int64       ", c.Flags.Int64("int64"))
+			fmt.Println("uint        ", c.Flags.Uint("uint"))
+			fmt.Println("uint64      ", c.Flags.Uint64("uint64"))
+			fmt.Println("float       ", c.Flags.Float64("float"))
+			fmt.Println("stringSlice ", c.Flags.StringSlice("stringSlice"))
 			return nil
 		},
 	})

--- a/sample/full/cmd/flags.go
+++ b/sample/full/cmd/flags.go
@@ -42,6 +42,7 @@ func init() {
 			f.Uint("u", "uint", 3, "test uint")
 			f.Uint64("j", "uint64", 4, "test uint64")
 			f.Float64("f", "float", 5.55, "test float64")
+			f.StringSlice("H","Headers",[]string{},"string slice")
 		},
 		Run: func(c *grumble.Context) error {
 			fmt.Println("duration ", c.Flags.Duration("duration"))
@@ -50,6 +51,7 @@ func init() {
 			fmt.Println("uint     ", c.Flags.Uint("uint"))
 			fmt.Println("uint64   ", c.Flags.Uint64("uint64"))
 			fmt.Println("float    ", c.Flags.Float64("float"))
+			fmt.Println("StringSLice",c.Flags.StringSlice("Headers"))
 			return nil
 		},
 	})


### PR DESCRIPTION
**add StringSlice flag**

`f.StringSlice("H","Headers",[]string{},"string slice")`
Enter multiple identical flags in the command line, and use c.Flags.StringSlice() to get a []string.
**eg**: 
```
enter: flags -H var1=val1 -H var2=val2,
get:    [var1=val1 var2=val2]
```
![image](https://user-images.githubusercontent.com/24365224/119089752-3af77780-ba3d-11eb-9c72-9dfa2264e281.png)
This StringSlice flag is suitable for sending http request messages.
**eg**:
`Repeat -u test.com -H "Accept: application/json, text/javascript, */*; q=0.01" -H "Origin: https://test.com"`

closes #30