### PR TITLE
refactor flags & add missing flag base types

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ Builtin support for multiple lines.
 ... command
 ```
 
+## Flags
+
+You can pass flags in two ways: `cmd --flag value` or `cmd --flag=value`  
+There are some exceptions/additions to this:  
+- bool: `cmd --boolflag` offer a third option that does require a value
+- string: `cmd --stringflag="some test string"` leads to value `some test string`, as double quotes are stripped from the value
+
 ## Samples
 
 Check out the [sample directory](/sample) for some detailed examples.

--- a/flagmap.go
+++ b/flagmap.go
@@ -53,11 +53,7 @@ func (f FlagMap) copyMissingValues(m FlagMap, copyDefault bool) {
 // String returns the given flag value as string.
 // Panics if not present. Flags must be registered.
 func (f FlagMap) String(long string) string {
-	i := f[long]
-	if i == nil {
-		panic(fmt.Errorf("missing flag value: flag '%s' not registered", long))
-	}
-	s, ok := i.Value.(string)
+	s, ok := f.flagValOrPanic(long).(string)
 	if !ok {
 		panic(fmt.Errorf("failed to assert flag '%s' to string", long))
 	}
@@ -67,11 +63,7 @@ func (f FlagMap) String(long string) string {
 // Bool returns the given flag value as boolean.
 // Panics if not present. Flags must be registered.
 func (f FlagMap) Bool(long string) bool {
-	i := f[long]
-	if i == nil {
-		panic(fmt.Errorf("missing flag value: flag '%s' not registered", long))
-	}
-	b, ok := i.Value.(bool)
+	b, ok := f.flagValOrPanic(long).(bool)
 	if !ok {
 		panic(fmt.Errorf("failed to assert flag '%s' to bool", long))
 	}
@@ -81,13 +73,39 @@ func (f FlagMap) Bool(long string) bool {
 // Int returns the given flag value as int.
 // Panics if not present. Flags must be registered.
 func (f FlagMap) Int(long string) int {
-	i := f[long]
-	if i == nil {
-		panic(fmt.Errorf("missing flag value: flag '%s' not registered", long))
-	}
-	v, ok := i.Value.(int)
+	v, ok := f.flagValOrPanic(long).(int)
 	if !ok {
 		panic(fmt.Errorf("failed to assert flag '%s' to int", long))
+	}
+	return v
+}
+
+// Int8 returns the given flag value as int8.
+// Panics if not present. Flags must be registered.
+func (f FlagMap) Int8(long string) int8 {
+	v, ok := f.flagValOrPanic(long).(int8)
+	if !ok {
+		panic(fmt.Errorf("failed to assert flag '%s' to int8", long))
+	}
+	return v
+}
+
+// Int16 returns the given flag value as int16.
+// Panics if not present. Flags must be registered.
+func (f FlagMap) Int16(long string) int16 {
+	v, ok := f.flagValOrPanic(long).(int16)
+	if !ok {
+		panic(fmt.Errorf("failed to assert flag '%s' to int16", long))
+	}
+	return v
+}
+
+// Int32 returns the given flag value as int32.
+// Panics if not present. Flags must be registered.
+func (f FlagMap) Int32(long string) int32 {
+	v, ok := f.flagValOrPanic(long).(int32)
+	if !ok {
+		panic(fmt.Errorf("failed to assert flag '%s' to int32", long))
 	}
 	return v
 }
@@ -95,11 +113,7 @@ func (f FlagMap) Int(long string) int {
 // Int64 returns the given flag value as int64.
 // Panics if not present. Flags must be registered.
 func (f FlagMap) Int64(long string) int64 {
-	i := f[long]
-	if i == nil {
-		panic(fmt.Errorf("missing flag value: flag '%s' not registered", long))
-	}
-	v, ok := i.Value.(int64)
+	v, ok := f.flagValOrPanic(long).(int64)
 	if !ok {
 		panic(fmt.Errorf("failed to assert flag '%s' to int64", long))
 	}
@@ -109,13 +123,39 @@ func (f FlagMap) Int64(long string) int64 {
 // Uint returns the given flag value as uint.
 // Panics if not present. Flags must be registered.
 func (f FlagMap) Uint(long string) uint {
-	i := f[long]
-	if i == nil {
-		panic(fmt.Errorf("missing flag value: flag '%s' not registered", long))
-	}
-	v, ok := i.Value.(uint)
+	v, ok := f.flagValOrPanic(long).(uint)
 	if !ok {
 		panic(fmt.Errorf("failed to assert flag '%s' to uint", long))
+	}
+	return v
+}
+
+// Uint8 returns the given flag value as uint8.
+// Panics if not present. Flags must be registered.
+func (f FlagMap) Uint8(long string) uint8 {
+	v, ok := f.flagValOrPanic(long).(uint8)
+	if !ok {
+		panic(fmt.Errorf("failed to assert flag '%s' to uint8", long))
+	}
+	return v
+}
+
+// Uint16 returns the given flag value as uint16.
+// Panics if not present. Flags must be registered.
+func (f FlagMap) Uint16(long string) uint16 {
+	v, ok := f.flagValOrPanic(long).(uint16)
+	if !ok {
+		panic(fmt.Errorf("failed to assert flag '%s' to uint16", long))
+	}
+	return v
+}
+
+// Uint32 returns the given flag value as uint32.
+// Panics if not present. Flags must be registered.
+func (f FlagMap) Uint32(long string) uint32 {
+	v, ok := f.flagValOrPanic(long).(uint32)
+	if !ok {
+		panic(fmt.Errorf("failed to assert flag '%s' to uint32", long))
 	}
 	return v
 }
@@ -123,13 +163,19 @@ func (f FlagMap) Uint(long string) uint {
 // Uint64 returns the given flag value as uint64.
 // Panics if not present. Flags must be registered.
 func (f FlagMap) Uint64(long string) uint64 {
-	i := f[long]
-	if i == nil {
-		panic(fmt.Errorf("missing flag value: flag '%s' not registered", long))
-	}
-	v, ok := i.Value.(uint64)
+	v, ok := f.flagValOrPanic(long).(uint64)
 	if !ok {
 		panic(fmt.Errorf("failed to assert flag '%s' to uint64", long))
+	}
+	return v
+}
+
+// Float32 returns the given flag value as float32.
+// Panics if not present. Flags must be registered.
+func (f FlagMap) Float32(long string) float32 {
+	v, ok := f.flagValOrPanic(long).(float32)
+	if !ok {
+		panic(fmt.Errorf("failed to assert flag '%s' to float32", long))
 	}
 	return v
 }
@@ -137,11 +183,7 @@ func (f FlagMap) Uint64(long string) uint64 {
 // Float64 returns the given flag value as float64.
 // Panics if not present. Flags must be registered.
 func (f FlagMap) Float64(long string) float64 {
-	i := f[long]
-	if i == nil {
-		panic(fmt.Errorf("missing flag value: flag '%s' not registered", long))
-	}
-	v, ok := i.Value.(float64)
+	v, ok := f.flagValOrPanic(long).(float64)
 	if !ok {
 		panic(fmt.Errorf("failed to assert flag '%s' to float64", long))
 	}
@@ -151,13 +193,20 @@ func (f FlagMap) Float64(long string) float64 {
 // Duration returns the given flag value as duration.
 // Panics if not present. Flags must be registered.
 func (f FlagMap) Duration(long string) time.Duration {
-	i := f[long]
-	if i == nil {
-		panic(fmt.Errorf("missing flag value: flag '%s' not registered", long))
-	}
-	v, ok := i.Value.(time.Duration)
+	v, ok := f.flagValOrPanic(long).(time.Duration)
 	if !ok {
 		panic(fmt.Errorf("failed to assert flag '%s' to duration", long))
 	}
 	return v
+}
+
+// flagValOrPanic is small convenience method that checks if the value for
+// the given flag identitifer is set on f.
+// If not, a panic is triggered.
+func (f FlagMap) flagValOrPanic(long string) interface{} {
+	fi, ok := f[long]
+	if !ok {
+		panic(fmt.Errorf("flag '%s' not registered", long))
+	}
+	return fi.Value
 }

--- a/flags.go
+++ b/flags.go
@@ -32,23 +32,29 @@ import (
 	"time"
 )
 
-type parseFlagFunc func(flag, equalVal string, args []string, res FlagMap) ([]string, bool, error)
-type defaultFlagFunc func(res FlagMap)
+type flagItemParser func(value string) (interface{}, error)
 
 type flagItem struct {
-	Short           string
-	Long            string
-	Help            string
-	HelpArgs        string
-	HelpShowDefault bool
-	Default         interface{}
+	Short    string
+	Long     string
+	Help     string
+	HelpArgs string
+	Default  interface{}
+
+	parser          flagItemParser
+	allowEmptyValue bool
+}
+
+// showDefault returns true, if the default parameter should be shown in a help message.
+func (fi *flagItem) showDefault() bool {
+	// Only for bool types we do not want to show the default value.
+	_, ok := fi.Default.(bool)
+	return !ok
 }
 
 // Flags holds all the registered flags.
 type Flags struct {
-	parsers  []parseFlagFunc
-	defaults map[string]defaultFlagFunc
-	list     []*flagItem
+	list []*flagItem
 }
 
 // empty returns true, if the flags are empty.
@@ -58,27 +64,34 @@ func (f *Flags) empty() bool {
 
 // sort the flags by their name.
 func (f *Flags) sort() {
-	sort.Slice(f.list, func(i, j int) bool {
-		return f.list[i].Long < f.list[j].Long
-	})
+	sort.Slice(f.list, func(i, j int) bool { return f.list[i].Long < f.list[j].Long })
 }
 
+// match returns true, if the given flag matches the given short or long identifier.
+func (f *Flags) match(flag, short, long string) bool {
+	return (len(short) > 0 && flag == "-"+short) || (len(long) > 0 && flag == "--"+long)
+}
+
+// register creates a new flag item in f with the given properties.
+// The parser is a func that receives the parsed value from the arguments
+// and must convert it to the correctly typed value of its flag.
+// To prevent each flag having to check whether the value is empty or not,
+// the flag allowEmptyValue can be set to false, if the flag must have a value.
 func (f *Flags) register(
 	short, long, help, helpArgs string,
-	helpShowDefault bool,
 	defaultValue interface{},
-	df defaultFlagFunc,
-	pf parseFlagFunc,
+	allowEmptyValue bool,
+	parser flagItemParser,
 ) {
 	// Validate.
 	if len(short) > 1 {
-		panic(fmt.Errorf("invalid short flag: '%s': must be a single character", short))
-	} else if strings.HasPrefix(short, "-") {
-		panic(fmt.Errorf("invalid short flag: '%s': must not start with a '-'", short))
+		panic(fmt.Errorf("invalid short flag: '%s' - must be a single character", short))
+	} else if short == "-" {
+		panic(fmt.Errorf("invalid short flag: '%s' - must not equal '-'", short))
 	} else if len(long) == 0 {
 		panic(fmt.Errorf("empty long flag: short='%s'", short))
 	} else if strings.HasPrefix(long, "-") {
-		panic(fmt.Errorf("invalid long flag: '%s': must not start with a '-'", long))
+		panic(fmt.Errorf("invalid long flag: '%s' - must not start with a '-'", long))
 	} else if len(help) == 0 {
 		panic(fmt.Errorf("empty flag help message for flag: '%s'", long))
 	}
@@ -94,79 +107,102 @@ func (f *Flags) register(
 		}
 	}
 
+	// Add the new flag item.
 	f.list = append(f.list, &flagItem{
-		Short:           short,
-		Long:            long,
-		Help:            help,
-		HelpShowDefault: helpShowDefault,
-		HelpArgs:        helpArgs,
-		Default:         defaultValue,
+		Short:    short,
+		Long:     long,
+		Help:     help,
+		HelpArgs: helpArgs,
+		Default:  defaultValue,
+
+		parser:          parser,
+		allowEmptyValue: allowEmptyValue,
 	})
-
-	if f.defaults == nil {
-		f.defaults = make(map[string]defaultFlagFunc)
-	}
-	f.defaults[long] = df
-
-	f.parsers = append(f.parsers, pf)
 }
 
-func (f *Flags) match(flag, short, long string) bool {
-	return (len(short) > 0 && flag == "-"+short) ||
-		(len(long) > 0 && flag == "--"+long)
-}
-
+// parse iterates the given args and parses all found flags from it.
+// The leftover, not parsed arguments are returned.
+// The parsed flag results are written to res.
 func (f *Flags) parse(args []string, res FlagMap) ([]string, error) {
-	var err error
-	var parsed bool
+	// There are 3 ways a flag can be given:
+	//   1. `--flag`       : identifier only.
+	//   2. `--flag value` : identifier and value in separate args.
+	//   3. `--flag=value` : identifier and value joined by '=' in same arg.
 
-	// Parse all leading flags.
-Loop:
+ParseLoop:
 	for len(args) > 0 {
+		// Retrieve the next argument.
 		a := args[0]
+
+		// If the argument does not start with a hyphen, it is not a flag.
+		// We can stop the parsing loop then.
 		if !strings.HasPrefix(a, "-") {
-			break Loop
+			break ParseLoop
 		}
-		args = args[1:]
+		args = args[1:] // Pop the consumed argument.
 
 		// A double dash (--) is used to signify the end of command options,
 		// after which only positional arguments are accepted.
 		if a == "--" {
-			break Loop
+			break ParseLoop
 		}
 
-		pos := strings.Index(a, "=")
-		equalVal := ""
-		if pos > 0 {
-			equalVal = a[pos+1:]
+		// Check, if we must parse case 3 of the possible flag formats.
+		flagValue := ""
+		if pos := strings.Index(a, "="); pos > 0 {
+			flagValue = a[pos+1:]
 			a = a[:pos]
 		}
 
-		for _, p := range f.parsers {
-			args, parsed, err = p(a, equalVal, args, res)
-			if err != nil {
-				return nil, err
-			} else if parsed {
-				continue Loop
+		// Find the registered flag item.
+		var (
+			parsedVal interface{}
+			err       error
+		)
+		for _, fi := range f.list {
+			if f.match(a, fi.Short, fi.Long) {
+				// Check, if the flag requires a value and if yes,
+				// if there is one left in the arguments.
+				// This is case 2 of the possible flag formats.
+				if !fi.allowEmptyValue && flagValue == "" {
+					if len(args) == 0 {
+						return nil, fmt.Errorf("missing value for flag %s", fi.Long)
+					}
+
+					flagValue = args[0]
+					args = args[1:] // Pop the consumed argument.
+				} else if fi.allowEmptyValue && len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+					// Special check for flags that allow empty values, as the next argument can only
+					// be the value for case 2, if it does not start with a hyphen, as that would be
+					// the next flag or delimiter between flags and positional arguments '--'.
+					flagValue = args[0]
+					args = args[1:] // Pop the consumed argument.
+				}
+
+				// Run the parser of this flag against the provided value.
+				parsedVal, err = fi.parser(flagValue)
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse flag %s: %v", fi.Long, err)
+				}
+				res[fi.Long] = &FlagMapItem{Value: parsedVal}
+
+				// Continue to next flag.
+				continue ParseLoop
 			}
 		}
+
 		return nil, fmt.Errorf("invalid flag: %s", a)
 	}
 
-	// Finally set all the default values for not passed flags.
-	if f.defaults == nil {
-		return args, nil
-	}
-
-	for _, i := range f.list {
-		if _, ok := res[i.Long]; ok {
-			continue
+	// Set the default value for every flag that has not been
+	// provided by the arguments.
+	for _, fi := range f.list {
+		if _, ok := res[fi.Long]; !ok {
+			res[fi.Long] = &FlagMapItem{
+				Value:     fi.Default,
+				IsDefault: true,
+			}
 		}
-		df, ok := f.defaults[i.Long]
-		if !ok {
-			return nil, fmt.Errorf("invalid flag: missing default function: %s", i.Long)
-		}
-		df(res)
 	}
 
 	return args, nil
@@ -179,34 +215,9 @@ func (f *Flags) StringL(long, defaultValue, help string) {
 
 // String registers a string flag.
 func (f *Flags) String(short, long, defaultValue, help string) {
-	f.register(short, long, help, "string", true, defaultValue,
-		func(res FlagMap) {
-			res[long] = &FlagMapItem{
-				Value:     defaultValue,
-				IsDefault: true,
-			}
-		},
-		func(flag, equalVal string, args []string, res FlagMap) ([]string, bool, error) {
-			if !f.match(flag, short, long) {
-				return args, false, nil
-			}
-			if len(equalVal) > 0 {
-				res[long] = &FlagMapItem{
-					Value:     trimQuotes(equalVal),
-					IsDefault: false,
-				}
-				return args, true, nil
-			}
-			if len(args) == 0 {
-				return args, false, fmt.Errorf("missing string value for flag: %s", flag)
-			}
-			res[long] = &FlagMapItem{
-				Value:     args[0],
-				IsDefault: false,
-			}
-			args = args[1:]
-			return args, true, nil
-		})
+	f.register(short, long, help, "string", defaultValue, false, func(value string) (interface{}, error) {
+		return trimQuotes(value), nil
+	})
 }
 
 // BoolL same as Bool, but without a shorthand.
@@ -216,34 +227,13 @@ func (f *Flags) BoolL(long string, defaultValue bool, help string) {
 
 // Bool registers a boolean flag.
 func (f *Flags) Bool(short, long string, defaultValue bool, help string) {
-	f.register(short, long, help, "", false, defaultValue,
-		func(res FlagMap) {
-			res[long] = &FlagMapItem{
-				Value:     defaultValue,
-				IsDefault: true,
-			}
-		},
-		func(flag, equalVal string, args []string, res FlagMap) ([]string, bool, error) {
-			if !f.match(flag, short, long) {
-				return args, false, nil
-			}
-			if len(equalVal) > 0 {
-				b, err := strconv.ParseBool(equalVal)
-				if err != nil {
-					return args, false, fmt.Errorf("invalid boolean value for flag: %s", flag)
-				}
-				res[long] = &FlagMapItem{
-					Value:     b,
-					IsDefault: false,
-				}
-				return args, true, nil
-			}
-			res[long] = &FlagMapItem{
-				Value:     true,
-				IsDefault: false,
-			}
-			return args, true, nil
-		})
+	f.register(short, long, help, "bool", defaultValue, true, func(value string) (interface{}, error) {
+		// For bool flags the value is optional.
+		if value == "" {
+			return true, nil
+		}
+		return strconv.ParseBool(value)
+	})
 }
 
 // IntL same as Int, but without a shorthand.
@@ -253,36 +243,61 @@ func (f *Flags) IntL(long string, defaultValue int, help string) {
 
 // Int registers an int flag.
 func (f *Flags) Int(short, long string, defaultValue int, help string) {
-	f.register(short, long, help, "int", true, defaultValue,
-		func(res FlagMap) {
-			res[long] = &FlagMapItem{
-				Value:     defaultValue,
-				IsDefault: true,
-			}
-		},
-		func(flag, equalVal string, args []string, res FlagMap) ([]string, bool, error) {
-			if !f.match(flag, short, long) {
-				return args, false, nil
-			}
-			var vStr string
-			if len(equalVal) > 0 {
-				vStr = equalVal
-			} else if len(args) > 0 {
-				vStr = args[0]
-				args = args[1:]
-			} else {
-				return args, false, fmt.Errorf("missing int value for flag: %s", flag)
-			}
-			i, err := strconv.Atoi(vStr)
-			if err != nil {
-				return args, false, fmt.Errorf("invalid int value for flag: %s", flag)
-			}
-			res[long] = &FlagMapItem{
-				Value:     i,
-				IsDefault: false,
-			}
-			return args, true, nil
-		})
+	f.register(short, long, help, "int", defaultValue, false, func(value string) (interface{}, error) {
+		v, err := strconv.ParseInt(value, 10, 0)
+		if err != nil {
+			return nil, err
+		}
+		return int(v), nil
+	})
+}
+
+// Int8L same as Int8, but without a shorthand.
+func (f *Flags) Int8L(long string, defaultValue int8, help string) {
+	f.Int8("", long, defaultValue, help)
+}
+
+// Int8 registers an int8 flag.
+func (f *Flags) Int8(short, long string, defaultValue int8, help string) {
+	f.register(short, long, help, "int8", defaultValue, false, func(value string) (interface{}, error) {
+		v, err := strconv.ParseInt(value, 10, 8)
+		if err != nil {
+			return nil, err
+		}
+		return int8(v), nil
+	})
+}
+
+// Int16L same as Int16, but without a shorthand.
+func (f *Flags) Int16L(long string, defaultValue int16, help string) {
+	f.Int16("", long, defaultValue, help)
+}
+
+// Int16 registers an int16 flag.
+func (f *Flags) Int16(short, long string, defaultValue int16, help string) {
+	f.register(short, long, help, "int16", defaultValue, false, func(value string) (interface{}, error) {
+		v, err := strconv.ParseInt(value, 10, 16)
+		if err != nil {
+			return nil, err
+		}
+		return int16(v), nil
+	})
+}
+
+// Int32L same as Int32, but without a shorthand.
+func (f *Flags) Int32L(long string, defaultValue int32, help string) {
+	f.Int32("", long, defaultValue, help)
+}
+
+// Int32 registers an int32 flag.
+func (f *Flags) Int32(short, long string, defaultValue int32, help string) {
+	f.register(short, long, help, "int32", defaultValue, false, func(value string) (interface{}, error) {
+		v, err := strconv.ParseInt(value, 10, 32)
+		if err != nil {
+			return nil, err
+		}
+		return int32(v), nil
+	})
 }
 
 // Int64L same as Int64, but without a shorthand.
@@ -292,36 +307,9 @@ func (f *Flags) Int64L(long string, defaultValue int64, help string) {
 
 // Int64 registers an int64 flag.
 func (f *Flags) Int64(short, long string, defaultValue int64, help string) {
-	f.register(short, long, help, "int", true, defaultValue,
-		func(res FlagMap) {
-			res[long] = &FlagMapItem{
-				Value:     defaultValue,
-				IsDefault: true,
-			}
-		},
-		func(flag, equalVal string, args []string, res FlagMap) ([]string, bool, error) {
-			if !f.match(flag, short, long) {
-				return args, false, nil
-			}
-			var vStr string
-			if len(equalVal) > 0 {
-				vStr = equalVal
-			} else if len(args) > 0 {
-				vStr = args[0]
-				args = args[1:]
-			} else {
-				return args, false, fmt.Errorf("missing int value for flag: %s", flag)
-			}
-			i, err := strconv.ParseInt(vStr, 10, 64)
-			if err != nil {
-				return args, false, fmt.Errorf("invalid int value for flag: %s", flag)
-			}
-			res[long] = &FlagMapItem{
-				Value:     i,
-				IsDefault: false,
-			}
-			return args, true, nil
-		})
+	f.register(short, long, help, "int64", defaultValue, false, func(value string) (interface{}, error) {
+		return strconv.ParseInt(value, 10, 64)
+	})
 }
 
 // UintL same as Uint, but without a shorthand.
@@ -331,36 +319,61 @@ func (f *Flags) UintL(long string, defaultValue uint, help string) {
 
 // Uint registers an uint flag.
 func (f *Flags) Uint(short, long string, defaultValue uint, help string) {
-	f.register(short, long, help, "uint", true, defaultValue,
-		func(res FlagMap) {
-			res[long] = &FlagMapItem{
-				Value:     defaultValue,
-				IsDefault: true,
-			}
-		},
-		func(flag, equalVal string, args []string, res FlagMap) ([]string, bool, error) {
-			if !f.match(flag, short, long) {
-				return args, false, nil
-			}
-			var vStr string
-			if len(equalVal) > 0 {
-				vStr = equalVal
-			} else if len(args) > 0 {
-				vStr = args[0]
-				args = args[1:]
-			} else {
-				return args, false, fmt.Errorf("missing uint value for flag: %s", flag)
-			}
-			i, err := strconv.ParseUint(vStr, 10, 64)
-			if err != nil {
-				return args, false, fmt.Errorf("invalid uint value for flag: %s", flag)
-			}
-			res[long] = &FlagMapItem{
-				Value:     uint(i),
-				IsDefault: false,
-			}
-			return args, true, nil
-		})
+	f.register(short, long, help, "uint", defaultValue, false, func(value string) (interface{}, error) {
+		v, err := strconv.ParseUint(value, 10, 0)
+		if err != nil {
+			return nil, err
+		}
+		return uint(v), nil
+	})
+}
+
+// Uint8L same as Uint8, but without a shorthand.
+func (f *Flags) Uint8L(long string, defaultValue uint8, help string) {
+	f.Uint8("", long, defaultValue, help)
+}
+
+// Uint8 registers an uint8 flag.
+func (f *Flags) Uint8(short, long string, defaultValue uint8, help string) {
+	f.register(short, long, help, "uint8", defaultValue, false, func(value string) (interface{}, error) {
+		v, err := strconv.ParseUint(value, 10, 8)
+		if err != nil {
+			return nil, err
+		}
+		return uint8(v), nil
+	})
+}
+
+// Uint16L same as Uint16, but without a shorthand.
+func (f *Flags) Uint16L(long string, defaultValue uint16, help string) {
+	f.Uint16("", long, defaultValue, help)
+}
+
+// Uint16 registers an uint16 flag.
+func (f *Flags) Uint16(short, long string, defaultValue uint16, help string) {
+	f.register(short, long, help, "uint16", defaultValue, false, func(value string) (interface{}, error) {
+		v, err := strconv.ParseUint(value, 10, 16)
+		if err != nil {
+			return nil, err
+		}
+		return uint16(v), nil
+	})
+}
+
+// Uint32L same as Uint32, but without a shorthand.
+func (f *Flags) Uint32L(long string, defaultValue uint32, help string) {
+	f.Uint32("", long, defaultValue, help)
+}
+
+// Uint32 registers an uint32 flag.
+func (f *Flags) Uint32(short, long string, defaultValue uint32, help string) {
+	f.register(short, long, help, "uint32", defaultValue, false, func(value string) (interface{}, error) {
+		v, err := strconv.ParseUint(value, 10, 32)
+		if err != nil {
+			return nil, err
+		}
+		return uint32(v), nil
+	})
 }
 
 // Uint64L same as Uint64, but without a shorthand.
@@ -370,36 +383,22 @@ func (f *Flags) Uint64L(long string, defaultValue uint64, help string) {
 
 // Uint64 registers an uint64 flag.
 func (f *Flags) Uint64(short, long string, defaultValue uint64, help string) {
-	f.register(short, long, help, "uint", true, defaultValue,
-		func(res FlagMap) {
-			res[long] = &FlagMapItem{
-				Value:     defaultValue,
-				IsDefault: true,
-			}
-		},
-		func(flag, equalVal string, args []string, res FlagMap) ([]string, bool, error) {
-			if !f.match(flag, short, long) {
-				return args, false, nil
-			}
-			var vStr string
-			if len(equalVal) > 0 {
-				vStr = equalVal
-			} else if len(args) > 0 {
-				vStr = args[0]
-				args = args[1:]
-			} else {
-				return args, false, fmt.Errorf("missing uint value for flag: %s", flag)
-			}
-			i, err := strconv.ParseUint(vStr, 10, 64)
-			if err != nil {
-				return args, false, fmt.Errorf("invalid uint value for flag: %s", flag)
-			}
-			res[long] = &FlagMapItem{
-				Value:     i,
-				IsDefault: false,
-			}
-			return args, true, nil
-		})
+	f.register(short, long, help, "uint64", defaultValue, false, func(value string) (interface{}, error) {
+		return strconv.ParseUint(value, 10, 64)
+	})
+}
+
+// Float32L same as Float32, but without a shorthand.
+func (f *Flags) Float32L(long string, defaultValue float32, help string) {
+	f.Float32("", long, defaultValue, help)
+}
+
+// Float32 registers an float32 flag.
+func (f *Flags) Float32(short, long string, defaultValue float32, help string) {
+	f.register(short, long, help, "float32", defaultValue, false, func(value string) (interface{}, error) {
+		v, err := strconv.ParseFloat(value, 32)
+		return float32(v), err
+	})
 }
 
 // Float64L same as Float64, but without a shorthand.
@@ -409,36 +408,9 @@ func (f *Flags) Float64L(long string, defaultValue float64, help string) {
 
 // Float64 registers an float64 flag.
 func (f *Flags) Float64(short, long string, defaultValue float64, help string) {
-	f.register(short, long, help, "float", true, defaultValue,
-		func(res FlagMap) {
-			res[long] = &FlagMapItem{
-				Value:     defaultValue,
-				IsDefault: true,
-			}
-		},
-		func(flag, equalVal string, args []string, res FlagMap) ([]string, bool, error) {
-			if !f.match(flag, short, long) {
-				return args, false, nil
-			}
-			var vStr string
-			if len(equalVal) > 0 {
-				vStr = equalVal
-			} else if len(args) > 0 {
-				vStr = args[0]
-				args = args[1:]
-			} else {
-				return args, false, fmt.Errorf("missing float value for flag: %s", flag)
-			}
-			i, err := strconv.ParseFloat(vStr, 64)
-			if err != nil {
-				return args, false, fmt.Errorf("invalid float value for flag: %s", flag)
-			}
-			res[long] = &FlagMapItem{
-				Value:     i,
-				IsDefault: false,
-			}
-			return args, true, nil
-		})
+	f.register(short, long, help, "float64", defaultValue, false, func(value string) (interface{}, error) {
+		return strconv.ParseFloat(value, 64)
+	})
 }
 
 // DurationL same as Duration, but without a shorthand.
@@ -448,38 +420,13 @@ func (f *Flags) DurationL(long string, defaultValue time.Duration, help string) 
 
 // Duration registers a duration flag.
 func (f *Flags) Duration(short, long string, defaultValue time.Duration, help string) {
-	f.register(short, long, help, "duration", true, defaultValue,
-		func(res FlagMap) {
-			res[long] = &FlagMapItem{
-				Value:     defaultValue,
-				IsDefault: true,
-			}
-		},
-		func(flag, equalVal string, args []string, res FlagMap) ([]string, bool, error) {
-			if !f.match(flag, short, long) {
-				return args, false, nil
-			}
-			var vStr string
-			if len(equalVal) > 0 {
-				vStr = equalVal
-			} else if len(args) > 0 {
-				vStr = args[0]
-				args = args[1:]
-			} else {
-				return args, false, fmt.Errorf("missing duration value for flag: %s", flag)
-			}
-			d, err := time.ParseDuration(vStr)
-			if err != nil {
-				return args, false, fmt.Errorf("invalid duration value for flag: %s", flag)
-			}
-			res[long] = &FlagMapItem{
-				Value:     d,
-				IsDefault: false,
-			}
-			return args, true, nil
-		})
+	f.register(short, long, help, "duration", defaultValue, false, func(value string) (interface{}, error) {
+		return time.ParseDuration(value)
+	})
 }
 
+// trimQuotes removes a single '"' rune from the start and end of s.
+// s is returned unchanged, if it does not have both a prefix and suffix of '"'.
 func trimQuotes(s string) string {
 	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
 		return s[1 : len(s)-1]

--- a/functions.go
+++ b/functions.go
@@ -297,19 +297,19 @@ func printFlags(a *App, flags *Flags) {
 	flags.sort()
 
 	var output []string
-	for _, f := range flags.list {
-		long := "--" + f.Long
+	for _, fi := range flags.list {
+		long := "--" + fi.Long
 		short := ""
-		if len(f.Short) > 0 {
-			short = "-" + f.Short + ","
+		if len(fi.Short) > 0 {
+			short = "-" + fi.Short + ","
 		}
 
 		defaultValue := ""
-		if f.Default != nil && f.HelpShowDefault && len(fmt.Sprintf("%v", f.Default)) > 0 {
-			defaultValue = fmt.Sprintf("(default: %v)", f.Default)
+		if fi.showDefault() && len(fmt.Sprintf("%v", fi.Default)) > 0 {
+			defaultValue = fmt.Sprintf("(default: %v)", fi.Default)
 		}
 
-		output = append(output, fmt.Sprintf("%s | %s | %s |||| %s %s", short, long, f.HelpArgs, f.Help, defaultValue))
+		output = append(output, fmt.Sprintf("%s | %s | %s |||| %s %s", short, long, fi.HelpArgs, fi.Help, defaultValue))
 	}
 
 	if len(output) > 0 {

--- a/sample/full/cmd/flags.go
+++ b/sample/full/cmd/flags.go
@@ -36,20 +36,36 @@ func init() {
 		Name: "flags",
 		Help: "test flags",
 		Flags: func(f *grumble.Flags) {
-			f.Duration("d", "duration", time.Second, "duration test")
+			f.Bool("b", "bool", false, "test bool")
 			f.Int("i", "int", 1, "test int")
-			f.Int64("l", "int64", 2, "test int64")
+			f.Int8L("int8", -8, "test int8")
+			f.Int16L("int16", -16, "test int16")
+			f.Int32L("int32", -32, "test int32")
+			f.Int64L("int64", -64, "test int64")
 			f.Uint("u", "uint", 3, "test uint")
-			f.Uint64("j", "uint64", 4, "test uint64")
-			f.Float64("f", "float", 5.55, "test float64")
+			f.Uint8L("uint8", 8, "test uint8")
+			f.Uint16L("uint16", 16, "test uint16")
+			f.Uint32L("uint32", 32, "test uint32")
+			f.Uint64L("uint64", 64, "test uint64")
+			f.Float32L("float32", 5.55, "test float32")
+			f.Float64("f", "float64", 5.55, "test float64")
+			f.Duration("d", "duration", time.Second, "duration test")
 		},
 		Run: func(c *grumble.Context) error {
-			fmt.Println("duration ", c.Flags.Duration("duration"))
+			fmt.Println("bool     ", c.Flags.Bool("bool"))
 			fmt.Println("int      ", c.Flags.Int("int"))
+			fmt.Println("int8     ", c.Flags.Int8("int8"))
+			fmt.Println("int16    ", c.Flags.Int16("int16"))
+			fmt.Println("int32    ", c.Flags.Int32("int32"))
 			fmt.Println("int64    ", c.Flags.Int64("int64"))
 			fmt.Println("uint     ", c.Flags.Uint("uint"))
+			fmt.Println("uint8    ", c.Flags.Uint8("uint8"))
+			fmt.Println("uint16   ", c.Flags.Uint16("uint16"))
+			fmt.Println("uint32   ", c.Flags.Uint32("uint32"))
 			fmt.Println("uint64   ", c.Flags.Uint64("uint64"))
-			fmt.Println("float    ", c.Flags.Float64("float"))
+			fmt.Println("float32  ", c.Flags.Float32("float32"))
+			fmt.Println("float64  ", c.Flags.Float64("float64"))
+			fmt.Println("duration ", c.Flags.Duration("duration"))
 			return nil
 		},
 	})


### PR DESCRIPTION
This PR adds support for Flag types int8, int16, int32, uint8, uint16, uint32, float32.  

The PR also streamlines and simplifies the whole flag parsing process. IMO, this makes the code easier to read and requires only 1 line now for each of the flag types to be registered in the Flags.  

There is also just one type that represents the internal flag now (`flagItem`), where before this was splitted into the item and two funcs arcoss 3 slices.  

The change is backwards compatible, so flags can still be given in the following two forms:
- `cmd --flag value`
- `cmd --flag=value`
- exceptions:
  - `cmd --flag` for bool flags
  - `cmd --flag="multi word stuff"` leads to just `multi word stuff` being the value, for string flags.

These rules have now also been added to the README