### PR TITLE
config: Added CommandPreProc (allows shell vars)

### DIFF
--- a/app.go
+++ b/app.go
@@ -236,6 +236,15 @@ func (a *App) addCommand(cmd *Command, addHelpFlag bool) {
 
 // RunCommand runs a single command.
 func (a *App) RunCommand(args []string) error {
+	if a.config.CommandPreProc != nil {
+		var err error
+
+		args, err = a.config.CommandPreProc(args)
+		if err != nil {
+			return fmt.Errorf("command preprocessor failed - %w", err)
+		}
+	}
+
 	// Parse the arguments string and obtain the command path to the root,
 	// and the command flags.
 	cmds, fg, args, err := a.commands.parse(args, a.flagMap, false)

--- a/config.go
+++ b/config.go
@@ -74,8 +74,23 @@ type Config struct {
 	HelpSubCommands       bool
 	HelpHeadlineColor     *color.Color
 
-	// Override default iterrupt handler
+	// Override default iterrupt handler.
 	InterruptHandler func(a *App, count int)
+
+	// CommandPreProc is an optional function that allows callers
+	// to modify the command string and its arguments prior to
+	// looking up the command code and executing it. This field
+	// is useful for implementing variable replacement using
+	// functionality like os.Expand (ps: "PreProc" here means
+	// "preprocessor").
+	//
+	// This function receives the list of strings typed by the user
+	// and returns the new list of strings to use in the RunCommand
+	// method. An optional error can be returned as well which will
+	// stop the command from being executed.
+	//
+	// This field is ignored if it is nil.
+	CommandPreProc func(args []string) ([]string, error)
 }
 
 // SetDefaults sets the default values if not set.


### PR DESCRIPTION
This commit adds a new optional Config field that allows developers to intercept the list of strings typed by a user prior to looking up a command and running the relevant code.

The main goal of this code is to allow variable replacement, though it can be potentially used for other useful functionality.

Please refer to the code comments for more information on the desired behavior of this code.

ps: If this project is still maintained, can you please create a new tag? (even if this change is not merged, there is code in the main branch that is unmerged - thank you!)